### PR TITLE
Add Private label Payment Method DTOs

### DIFF
--- a/PagarMe.ConsoleTest/Program.cs
+++ b/PagarMe.ConsoleTest/Program.cs
@@ -21,7 +21,7 @@ namespace PagarMe.ConsoleTest
             {
                 AccountManagementKey = "amk",
                 MpToken = "token",
-                SecretKey = "sk_test_zL1YeWiWqfrx5GgZ",
+                SecretKey = "sk",
                 RequestKey = "rk"
             };
 

--- a/PagarMe.ConsoleTest/Program.cs
+++ b/PagarMe.ConsoleTest/Program.cs
@@ -1,6 +1,7 @@
 ﻿using PagarMe.Models.Request;
 using PagarMe.Models.Webhooks;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace PagarMe.ConsoleTest
 {
@@ -16,7 +17,7 @@ namespace PagarMe.ConsoleTest
             {
                 AccountManagementKey = "amk",
                 MpToken = "token",
-                SecretKey = "sk",
+                SecretKey = "sk_test_zL1YeWiWqfrx5GgZ",
                 RequestKey = "rk"
             };
 
@@ -32,6 +33,64 @@ namespace PagarMe.ConsoleTest
             client.Charge.CancelCharge("idempotency-key", "ch_id");
 
             client.Order.CreateOrder("idempotency-key", new CreateOrderRequest());
+
+            var createOrderRequest = new CreateOrderRequest
+            {
+                Items = new List<CreateOrderItemRequest>
+                {
+                    new CreateOrderItemRequest
+                    {
+                        Amount = 5000,
+                        Code = "12345",
+                        Quantity = 1,
+                        Description = "It just works"
+                    }
+                },
+                
+                Customer = new CreateCustomerRequest
+                {
+                    Name = "Test da Silva",
+                    Document = "80487236033",
+                    Email = "teste@testando.com",
+                    Type = "individual",
+                    Phones = new CreatePhonesRequest
+                    {
+                        HomePhone = new CreatePhoneRequest{
+                            AreaCode = "21",
+                            CountryCode = "55",
+                            Number = "12344321"
+                        }
+                    }
+                },
+
+                Payments = new List<CreatePaymentRequest>
+                {
+                    new CreatePaymentRequest
+                    {
+                        Amount = 5000,
+                        PaymentMethod = "private_label",
+                        PrivateLabel = new CreatePrivateLabelPaymentRequest
+                        {
+                            Capture = true,
+                            Installments = 1,
+                            StatementDescriptor = "No Quarter",
+                            Card = new CreateCardRequest
+                            {
+                                Number = "4000000000000010",
+                                Cvv = "123",
+                                ExpMonth = 12,
+                                ExpYear = 2030,
+                                Brand = "elo",
+                                Label = "Pernambucanas",
+                                HolderName = "Teste Da Silva",
+                                HolderDocument = "80487236033"
+                            }
+                        }
+                    }
+                }
+            };
+            var createOrderResponse = client.Order.CreateOrder("idempotency-key", createOrderRequest);
+            System.Console.WriteLine(createOrderResponse);
 
             // Capture
             var captureRequest = new CreateCaptureChargeRequest()

--- a/PagarMe/Models/Request/CreateCardRequest.cs
+++ b/PagarMe/Models/Request/CreateCardRequest.cs
@@ -32,5 +32,7 @@ namespace PagarMe.Models.Request
         public bool PrivateLabel { get; set; }
 
         public string Type { get; set; } = "credit";
+
+        public string Label { get; set; }
     }
 }

--- a/PagarMe/Models/Request/CreatePaymentRequest.cs
+++ b/PagarMe/Models/Request/CreatePaymentRequest.cs
@@ -19,6 +19,8 @@ namespace PagarMe.Models.Request
 
         public CreateCreditCardPaymentRequest CreditCard { get; set; }
 
+        public CreatePrivateLabelPaymentRequest PrivateLabel { get; set; }
+
         public string Currency { get; set; }
 
         public CreateCustomerRequest Customer { get; set; }

--- a/PagarMe/Models/Request/CreatePrivateLabelPaymentRequest.cs
+++ b/PagarMe/Models/Request/CreatePrivateLabelPaymentRequest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PagarMe.Models.Request
+{
+    public class CreatePrivateLabelPaymentRequest
+    {
+        public bool Capture { get; set; }
+        public int Installments { get; set; }
+        public string StatementDescriptor { get; set; }
+        public CreateCardRequest Card { get; set; }
+    }
+}

--- a/PagarMe/Models/Response/GetCardResponse.cs
+++ b/PagarMe/Models/Response/GetCardResponse.cs
@@ -39,5 +39,7 @@ namespace PagarMe.Models.Response
         public string Type { get; set; }
 
         public DateTime UpdatedAt { get; set; }
+
+        public string Label { get; set; }
     }
 }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/pj1dfdmYr4vXoX2V6v/giphy-downsized-large.gif)

### Status

READY

### Whats?

Added Private Label DTOs.

### Why?

In order to use cobranded labels on Pagar.me, it is necessary to send the correct fields on CreateOrderRequest. This require a private_label field.

### How?

By adding new DTOs and extending previous existing ones, it was possible to solve the issue.

### Attachments

PrivateLabel order created via SDK:
![Evidencia](https://user-images.githubusercontent.com/49206390/162291055-c0c2a2b0-9099-49d8-a636-f5e7d8b2a64d.PNG)

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
